### PR TITLE
use `rgars()` to access conditionalLogic array element

### DIFF
--- a/class-gf-field-repeater2.php
+++ b/class-gf-field-repeater2.php
@@ -155,7 +155,8 @@ class GF_Field_Repeater2 extends GF_Field {
 			for ($i = 1; $i < $dataArray['repeatCount'] + 1; $i++) {
 				foreach ($dataArray['children'] as $field_id=>$field) {
 					$inputNames = $field['inputs'];
-					$repeatSkips = $field['conditionalLogic']['skip'];
+					$repeatSkips = rgars($field, 'conditionalLogic/skip');
+
 
 					if (!is_array($inputNames)) { continue; }
 
@@ -310,7 +311,8 @@ class GF_Field_Repeater2 extends GF_Field {
 
 				if (array_key_exists('inputs', $field)) {
 					$inputNames = $field['inputs'];
-					$repeatSkips = $field['conditionalLogic']['skip'];
+					$repeatSkips = rgars($field, 'conditionalLogic/skip');
+
 
 					if (is_array($repeatSkips)) {
 						if (in_array($i, $repeatSkips) || in_array('all', $repeatSkips)) { continue; }


### PR DESCRIPTION
fixes PHP warnings on Undefined array key "conditionalLogic" / Trying to access array offset on value of type null