### PR TITLE
Fix setInputValue for checkbox

### DIFF
--- a/js/gf-repeater2.js
+++ b/js/gf-repeater2.js
@@ -889,7 +889,7 @@ function gfRepeater_getInputValue(inputElement) {
 */
 function gfRepeater_setInputValue(inputElement, inputValue) {
 	if (inputElement.is(':checkbox, :radio')) {
-		if (inputValue) { inputElement.prop('checked', true) } else { inputElement.prop('checked', false) }
+		if (inputValue == 'on' || inputElement.prop('value') === inputValue) { inputElement.prop('checked', true) } else { inputElement.prop('checked', false) }
 	} else {
 		inputElement.val(inputValue);
 	}


### PR DESCRIPTION
Hi,

there is an issue if we use, in repeater, a radio field with custom value.

## How to reproduce :
Create a form with a repeater and a radio field with two choice : 
- Yes
- No

Fill form and select "Yes" and the radio field
Leave at least one required field empty and submit form
We got an error (missing field) and form is display fill with previous value
Choice "No" of radio field will be checked instead of "Yes"

It come frome jquery.postcaptures which can return two kind of value for checkbox / radio :
- 'on' if radio have no value
- Value of the choice if exist
See here : https://github.com/ssut/jQuery-PostCapture/blob/master/src/capture.js#L43